### PR TITLE
fix: 修复结构体字段名是大驼峰式时解析出错问题

### DIFF
--- a/scanner/scann.go
+++ b/scanner/scann.go
@@ -22,7 +22,7 @@ func (s *Scanner) scanIdentifier() string {
 	offs := s.offset
 
 	for rdOffset, b := range s.src[s.rdOffset:] {
-		if 'a' <= b && b <= 'z' || 'A' <= b && 'Z' <= b || b == '_' || '0' <= b && b <= '9' {
+		if 'a' <= b && b <= 'z' || 'A' <= b && b <= 'Z' || b == '_' || '0' <= b && b <= '9' {
 			continue
 		}
 


### PR DESCRIPTION
解析以下 `type` 时会把 `First` 解析为字段名，把 `Name` 解析为字段类型
```go-zero
type (
	User {
	 	FirstName string 
        }
)
```